### PR TITLE
Add text reveal animations and increase image brightness

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ html,body{width:100%;height:100%;overflow:hidden;background:var(--bg);cursor:non
 #cur{position:fixed;pointer-events:none;z-index:9999;width:36px;height:36px;transform:translate(-50%,-50%);will-change:transform;}
 #cur svg{width:100%;height:100%;transition:transform .25s cubic-bezier(.16,1,.3,1);}
 #cur.big svg{transform:scale(1.9);}
-nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:flex;justify-content:space-between;align-items:center;}
+nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:flex;justify-content:space-between;align-items:center;opacity:0;transform:translateY(30px);transition:transform 1.5s cubic-bezier(.16,1,.3,1),opacity 1.5s ease;}
 .logo{font-size:12px;font-weight:700;letter-spacing:.45em;color:var(--off);text-decoration:none;display:flex;}
 .logo .l{display:inline-block;}
 .logo:hover .l{animation:ldrop .5s forwards;}
@@ -24,7 +24,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
 .navlinks li a span{display:inline-block;transition:transform .5s cubic-bezier(.19,1,.22,1);}
 .navlinks li a:hover span{transform:translateY(-5px);}
 .navlinks li a:hover span:nth-child(2n){transform:translateY(5px);}
-#hero{position:fixed;left:50%;top:24%;transform:translateX(-50%);z-index:100;text-align:center;pointer-events:none;user-select:none;}
+#hero{position:fixed;left:50%;top:24%;transform:translate(-50%,30px);z-index:100;text-align:center;pointer-events:none;user-select:none;opacity:0;transition:transform 1.5s cubic-bezier(.16,1,.3,1),opacity 1.5s ease;}
 .htitle{font-size:clamp(18px,4vw,60px);font-weight:400;letter-spacing:.55em;color:var(--off);line-height:1;margin-bottom:20px;}
 .hsub{font-size:9px;letter-spacing:.45em;color:var(--grey);opacity:.5;margin-bottom:44px;}
 .cta{pointer-events:all;display:inline-block;font-size:10px;letter-spacing:.35em;color:var(--off);text-decoration:none;padding:13px 30px;position:relative;cursor:none;}
@@ -36,11 +36,11 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
 #gallery{position:fixed;bottom:0;left:0;right:0;height:58vh;z-index:60;}
 #gstage{position:absolute;inset:0;perspective:1100px;perspective-origin:50% 42%;transform-style:preserve-3d;transition:none;}
 #gcont{position:absolute;top:50%;left:50%;width:1px;height:1px;transform-style:preserve-3d;}
-.pcounter{position:absolute;top:14px;right:52px;font-size:10px;letter-spacing:.35em;color:var(--grey);opacity:.55;z-index:10;}
+.pcounter{position:absolute;top:14px;right:52px;font-size:10px;letter-spacing:.35em;color:var(--grey);opacity:0;z-index:10;transform:translateY(30px);transition:transform 1.5s cubic-bezier(.16,1,.3,1),opacity 1.5s ease;}
 .card{position:absolute;width:190px;height:260px;margin:-130px -95px;transform-style:preserve-3d;cursor:none;will-change:transform,opacity;}
 .card .ci{width:100%;height:100%;position:relative;overflow:hidden;}
-.card img{width:100%;height:100%;object-fit:cover;display:block;filter:brightness(.55) contrast(1.15) grayscale(.5);transition:filter .4s;}
-.card:hover img{filter:brightness(.82) contrast(1.1) grayscale(0);}
+.card img{width:100%;height:100%;object-fit:cover;display:block;filter:brightness(.7) contrast(1.15) grayscale(.5);transition:filter .4s;}
+.card:hover img{filter:brightness(.95) contrast(1.1) grayscale(0);}
 .cinfo{position:absolute;bottom:0;left:0;right:0;padding:14px;background:linear-gradient(transparent,rgba(0,0,0,.9));transform:translateY(101%);transition:transform .32s cubic-bezier(.16,1,.3,1);}
 .card:hover .cinfo{transform:translateY(0);}
 .cname{font-size:9px;font-weight:700;letter-spacing:.3em;color:var(--off);margin-bottom:3px;}
@@ -57,13 +57,14 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
 .fstit{font-size:clamp(16px,2.5vw,30px);font-weight:700;letter-spacing:.3em;color:var(--off);margin-bottom:12px;}
 .fsyr{font-size:9px;letter-spacing:.35em;color:var(--grey);margin-bottom:22px;}
 .fsde{font-size:11px;line-height:2;color:rgba(255,255,255,.5);letter-spacing:.05em;}
-#foot{position:fixed;bottom:14px;left:52px;right:52px;z-index:100;display:flex;justify-content:space-between;pointer-events:none;}
+#foot{position:fixed;bottom:14px;left:52px;right:52px;z-index:100;display:flex;justify-content:space-between;pointer-events:none;opacity:0;transform:translateY(30px);transition:transform 1.5s cubic-bezier(.16,1,.3,1),opacity 1.5s ease;}
 .ft{font-size:8px;letter-spacing:.3em;color:var(--dark);}
 #load{position:fixed;inset:0;z-index:1000;background:var(--bg);display:flex;align-items:center;justify-content:center;transition:opacity .8s ease .3s;}
 #load.hide{opacity:0;pointer-events:none;}
 .loadtxt{font-size:9px;letter-spacing:.5em;color:var(--dark);animation:pulse 1.5s ease infinite;}
 @keyframes pulse{0%,100%{opacity:.15}50%{opacity:.7}}
 @media(max-width:700px){nav{padding:20px 24px;}.navlinks{display:none;}#hero{top:20%;}.htitle{font-size:16px;letter-spacing:.3em;}#foot{left:24px;right:24px;}.pcounter{right:24px;}.fsc{flex-direction:column;gap:28px;}.fstxt{flex:0 0 auto;}.fsx{right:20px;}}
+.reveal nav,.reveal #foot,.reveal .pcounter{opacity:1;transform:translateY(0);}.reveal #hero{opacity:1;transform:translate(-50%,0);}
 </style>
 </head>
 <body>
@@ -339,7 +340,7 @@ function placeCards() {
 
     const img = card.querySelector('img');
     if (img) {
-      const baseBright = i === hovered ? 0.82 : 0.55;
+      const baseBright = i === hovered ? 0.95 : 0.7;
       img.style.filter = `blur(${blur}px) brightness(${baseBright}) contrast(1.15) grayscale(${i === hovered ? 0 : 0.5})`;
     }
   });
@@ -351,6 +352,7 @@ function placeCards() {
 function stepCarousel(){
   tickTransition();             // 1. update introP and rotV
   if(!dragging){rot+=rotV;}     // 2. advance rotation
+  if(introP > 0.8) document.body.classList.add('reveal');
   placeCards();                 // 3. position cards using latest introP
 }
 


### PR DESCRIPTION
I have added animations to the text elements (navigation, hero, footer, and counter) so they reveal themselves from the bottom after the carousel images slow down. This is achieved by hiding them initially with `opacity: 0` and `translateY(30px)` and transitioning them to their visible state once the intro progress (`introP`) reaches 0.8. Additionally, I have increased the brightness of the gallery images to 0.7 (base) and 0.95 (hover) to improve visual clarity as requested.

---
*PR created automatically by Jules for task [13171669356887708917](https://jules.google.com/task/13171669356887708917) started by @Sohan258oss*