### PR TITLE
Update card hover brightness and navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
 .card{position:absolute;width:190px;height:260px;margin:-130px -95px;transform-style:preserve-3d;will-change:transform,opacity;cursor:pointer;}
 .card .ci{width:100%;height:100%;position:relative;overflow:hidden;}
 .card img{width:100%;height:100%;object-fit:cover;display:block;filter:brightness(.7) contrast(1.15) grayscale(.5);transition:filter .4s;}
-.card:hover img{filter:brightness(.95) contrast(1.1) grayscale(0);}
+.card:hover img{filter:brightness(1) contrast(1.1) grayscale(0);}
 .cinfo{position:absolute;bottom:0;left:0;right:0;padding:14px;background:linear-gradient(transparent,rgba(0,0,0,.9));transform:translateY(101%);transition:transform .32s cubic-bezier(.16,1,.3,1);}
 .card:hover .cinfo{transform:translateY(0);}
 .cname{font-size:9px;font-weight:700;letter-spacing:.3em;color:var(--off);margin-bottom:3px;}
@@ -124,13 +124,13 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
 <canvas id="bgc"></canvas>
 
 <nav>
-  <a class="logo" href="#">
+  <a class="logo" href="index.html">
     <span class="l">D</span><span class="l">4</span><span class="l">A</span><span class="l">S</span><span class="l">T</span><span class="l">U</span><span class="l">D</span><span class="l">I</span><span class="l">O</span>
   </a>
   <ul class="navlinks">
-    <li><a href="#"><span>P</span><span>R</span><span>O</span><span>J</span><span>E</span><span>C</span><span>T</span><span>S</span></a></li>
+    <li><a href="projects.html"><span>P</span><span>R</span><span>O</span><span>J</span><span>E</span><span>C</span><span>T</span><span>S</span></a></li>
     <li><a href="#"><span>A</span><span>P</span><span>P</span><span>R</span><span>O</span><span>A</span><span>C</span><span>H</span></a></li>
-    <li><a href="#"><span>A</span><span>B</span><span>O</span><span>U</span><span>T</span></a></li>
+    <li><a href="aboutus.html"><span>A</span><span>B</span><span>O</span><span>U</span><span>T</span></a></li>
     <li><a href="#"><span>C</span><span>O</span><span>N</span><span>T</span><span>A</span><span>C</span><span>T</span></a></li>
   </ul>
 </nav>


### PR DESCRIPTION
I have implemented the requested changes to `index.html`. 

1.  **Brighter card images on hover**: Updated the `.card:hover img` CSS rule to `filter: brightness(1) contrast(1.1) grayscale(0);`. This ensures that when a card is hovered, the image becomes fully bright and colored as specified. Note that there is existing JavaScript logic in the file that also manipulates the image filters; I have prioritized the requested CSS change as per the instructions.
2.  **Nav link hrefs**: Updated the following links in the `<nav>` section:
    *   Logo link changed from `#` to `index.html`.
    *   PROJECTS link changed from `#` to `projects.html`.
    *   ABOUT link changed from `#` to `aboutus.html`.
    *   APPROACH and CONTACT links remain as `#`.

The visual changes and link destinations have been verified.

---
*PR created automatically by Jules for task [16677754655443118558](https://jules.google.com/task/16677754655443118558) started by @Sohan258oss*