### PR TITLE
Add Responsive Mobile Menu with Unique Reveal Animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,37 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
 #load.hide{opacity:0;pointer-events:none;}
 .loadtxt{font-size:9px;letter-spacing:.5em;color:var(--dark);animation:pulse 1.5s ease infinite;}
 @keyframes pulse{0%,100%{opacity:.15}50%{opacity:.7}}
-@media(max-width:700px){nav{padding:20px 24px;}.navlinks{display:none;}#hero{top:20%;}.htitle{font-size:16px;letter-spacing:.3em;}#foot{bottom:8px;}.ft-main-row{gap:10px;flex-direction:column;}.ft-row{font-size:11px;}.fsc{flex-direction:column;gap:28px;}.fstxt{flex:0 0 auto;}.fsx{right:20px;}.logo img{height:28px;}}
+@media (max-width: 800px) {
+  nav{padding:20px 24px;}
+  .navlinks{display:none;}
+  #hero{top:20%;}
+  .htitle{font-size:16px;letter-spacing:.3em;}
+  #foot{bottom:8px;}
+  .ft-main-row{gap:10px;flex-direction:column;}
+  .ft-row{font-size:11px;}
+  .fsc{flex-direction:column;gap:28px;}
+  .fstxt{flex:0 0 auto;}
+  .fsx{right:20px;}
+  .logo img{height:28px;}
+  .ham{display:flex !important;flex-direction:column;gap:6px;cursor:pointer;z-index:3000;position:relative;}
+  .ham span{display:block;width:24px;height:1px;background:var(--off);transition:all .4s cubic-bezier(.16,1,.3,1);}
+  .ham span:nth-child(2){width:16px;align-self:flex-end;}
+  .ham span:nth-child(3){width:10px;align-self:flex-end;}
+  .ham.active span{width:24px !important;align-self:center;}
+  .ham.active span:nth-child(1){transform:translateY(7px) rotate(45deg);}
+  .ham.active span:nth-child(2){opacity:0;transform:translateX(10px);}
+  .ham.active span:nth-child(3){transform:translateY(-7px) rotate(-45deg);}
+}
+.ham{display:none;}
+#mob-nav{position:fixed;inset:0;background:var(--bg);z-index:2500;display:flex;flex-direction:column;align-items:center;justify-content:center;clip-path:polygon(0 0, 100% 0, 100% 0, 0 0);transition:clip-path .8s cubic-bezier(.77,0,.175,1);pointer-events:none;}
+#mob-nav.active{clip-path:polygon(0 0, 100% 0, 100% 100%, 0 100%);pointer-events:all;}
+.mob-links{list-style:none;text-align:center;}
+.mob-links li{margin:30px 0;overflow:hidden;}
+.mob-links a{font-size:28px;letter-spacing:.3em;color:var(--off);text-decoration:none;display:block;transform:translateY(100%);transition:transform .8s cubic-bezier(.16,1,.3,1);font-weight:300;}
+#mob-nav.active .mob-links a{transform:translateY(0);}
+#mob-nav.active .mob-links li:nth-child(1) a{transition-delay:.3s;}
+#mob-nav.active .mob-links li:nth-child(2) a{transition-delay:.4s;}
+#mob-nav.active .mob-links li:nth-child(3) a{transition-delay:.5s;}
 .reveal nav,.reveal #foot{opacity:1;transform:translateY(0);}.reveal #hero{opacity:1;transform:translate(-50%,0);}
 </style>
 </head>
@@ -133,6 +163,11 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
     <li><a href="projects.html"><span>P</span><span>R</span><span>O</span><span>J</span><span>E</span><span>C</span><span>T</span><span>S</span></a></li>
     <li><a href="aboutus.html"><span>A</span><span>B</span><span>O</span><span>U</span><span>T</span><span>U</span><span>S</span></a></li>
   </ul>
+  <div class="ham" id="ham">
+    <span></span>
+    <span></span>
+    <span></span>
+  </div>
 </nav>
 
 <div id="hero">
@@ -160,6 +195,14 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
       <div class="fsde" id="fsde"></div>
     </div>
   </div>
+</div>
+
+<div id="mob-nav">
+  <ul class="mob-links">
+    <li><a href="index.html">HOME</a></li>
+    <li><a href="projects.html">PROJECTS</a></li>
+    <li><a href="aboutus.html">ABOUT</a></li>
+  </ul>
 </div>
 
 <div id="foot">
@@ -463,6 +506,18 @@ function loop(){
   grX+=(tgrX-grX)*.05;grY+=(tgrY-grY)*.05;
   gcont.style.transform=`rotateX(${grX}deg) rotateY(${grY}deg)`;
 }
+
+const ham=document.getElementById('ham'),mobNav=document.getElementById('mob-nav');
+ham.addEventListener('click',()=>{
+  ham.classList.toggle('active');
+  mobNav.classList.toggle('active');
+});
+mobNav.querySelectorAll('a').forEach(a=>{
+  a.addEventListener('click',()=>{
+    ham.classList.remove('active');
+    mobNav.classList.remove('active');
+  });
+});
 
 window.addEventListener('resize',()=>{W=window.innerWidth;H=window.innerHeight;resize();});
 resize();


### PR DESCRIPTION
Implemented a unique, responsive mobile menu for the D4A Studio site. The menu features an architectural hamburger toggle and a full-screen overlay with a custom clip-path reveal animation. Navigation links are revealed using a staggered translate effect. The layout remains fully responsive from mobile (375px) up to large desktop screens, with no regressions to the existing 3D carousel animation.

---
*PR created automatically by Jules for task [17491404038454610466](https://jules.google.com/task/17491404038454610466) started by @Sohan258oss*