### PR TITLE
Synchronize Projects Page Navigation with Index Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:200;padding:28px 52px;display:fl
 .navlinks{display:flex;gap:44px;list-style:none;}
 .navlinks li a{font-size:10px;letter-spacing:.3em;color:var(--grey);text-decoration:none;display:flex;transition:color .4s;}
 .navlinks li a:hover{color:var(--off);}
-.navlinks li a span{display:inline-block;transition:transform .5s cubic-bezier(.19,1,.22,1);}
+.navlinks li a span{display:inline-block;transition:transform .5s cubic-bezier(.19,1,.22,1);pointer-events:none;}
 .navlinks li a:hover span{transform:translateY(-5px);}
 .navlinks li a:hover span:nth-child(2n){transform:translateY(5px);}
 #hero{position:fixed;left:50%;top:24%;transform:translate(-50%,30px);z-index:100;text-align:center;pointer-events:none;user-select:none;opacity:0;transition:transform 1.5s cubic-bezier(.16,1,.3,1),opacity 1.5s ease;}

--- a/projects.html
+++ b/projects.html
@@ -38,7 +38,7 @@
     :root {
       --gold: #c9a84c;
       --gold-light: #e0c070;
-      --dark: #0a0a0a;
+      --dark: #2A2A2A;
       --dark-2: #111111;
       --dark-3: #1a1a1a;
       --dark-card: #141414;
@@ -46,170 +46,55 @@
       --muted: rgba(240, 237, 232, 0.55);
       --radius: 4px;
       --header-h: 72px;
+      --bg:#0D0D0D;
+      --grey:#C0C0C0;
+      --off:#F5F4F0;
     }
 
-    /* ============================================================
-       NAVBAR
-    ============================================================ */
-    .header {
-      position: fixed;
-      top: 0; left: 0; right: 0;
-      z-index: 10000;
-      background: rgba(10, 10, 10, 0.85);
-      padding: 0.8rem 0;
-      border-bottom: 1px solid rgba(201, 168, 76, 0.15);
-      transition: background 0.4s ease;
+    nav{position:fixed;top:0;left:0;right:0;z-index:20000;padding:28px 52px;display:flex;justify-content:space-between;align-items:center;opacity:0;transform:translateY(30px);transition:transform 1.5s cubic-bezier(.16,1,.3,1),opacity 1.5s ease;}
+    .logo{font-size:12px;font-weight:700;letter-spacing:.45em;color:var(--off);text-decoration:none;display:flex;align-items:center;}
+    .logo img{height:38px;width:auto;display:block;object-fit:contain;}
+    .logo .l{display:inline-block;}
+    .logo:hover .l{animation:ldrop .5s forwards;}
+    @keyframes ldrop{0%{transform:translateY(0) skewX(0)}35%{transform:translateY(12px) skewX(-10deg);opacity:0}36%{transform:translateY(-12px) skewX(10deg);opacity:0}100%{transform:translateY(0) skewX(0);opacity:1}}
+    .navlinks{display:flex;gap:44px;list-style:none;}
+    .navlinks li a{font-size:10px;letter-spacing:.3em;color:var(--grey);text-decoration:none;display:flex;transition:color .4s;}
+    .navlinks li a:hover{color:var(--off);}
+    .navlinks li a span{display:inline-block;transition:transform .5s cubic-bezier(.19,1,.22,1);pointer-events:none;}
+    .navlinks li a:hover span{transform:translateY(-5px);}
+    .navlinks li a:hover span:nth-child(2n){transform:translateY(5px);}
+
+    .ham{display:none;}
+    #mob-nav{position:fixed;inset:0;background:var(--bg);z-index:25000;display:flex;flex-direction:column;align-items:center;justify-content:center;clip-path:polygon(0 0, 100% 0, 100% 0, 0 0);transition:clip-path .8s cubic-bezier(.77,0,.175,1);pointer-events:none;}
+    #mob-nav.active{clip-path:polygon(0 0, 100% 0, 100% 100%, 0 100%);pointer-events:all;}
+    .mob-links{list-style:none;text-align:center;}
+    .mob-links li{margin:30px 0;overflow:hidden;}
+    .mob-links a{font-size:28px;letter-spacing:.3em;color:var(--off);text-decoration:none;display:block;transform:translateY(100%);transition:transform .8s cubic-bezier(.16,1,.3,1);font-weight:300;}
+    #mob-nav.active .mob-links a{transform:translateY(0);}
+    #mob-nav.active .mob-links li:nth-child(1) a{transition-delay:.3s;}
+    #mob-nav.active .mob-links li:nth-child(2) a{transition-delay:.4s;}
+    #mob-nav.active .mob-links li:nth-child(3) a{transition-delay:.5s;}
+    .reveal nav{opacity:1;transform:translateY(0);}
+
+    @media (max-width: 800px) {
+      nav{padding:20px 24px;}
+      .navlinks{display:none;}
+      .logo img{height:28px;}
+      .ham{display:flex !important;flex-direction:column;gap:6px;cursor:pointer;z-index:30000;position:relative;}
+      .ham span{display:block;width:24px;height:1px;background:var(--off);transition:all .4s cubic-bezier(.16,1,.3,1);}
+      .ham span:nth-child(2){width:16px;align-self:flex-end;}
+      .ham span:nth-child(3){width:10px;align-self:flex-end;}
+      .ham.active span{width:24px !important;align-self:center;}
+      .ham.active span:nth-child(1){transform:translateY(7px) rotate(45deg);}
+      .ham.active span:nth-child(2){opacity:0;transform:translateX(10px);}
+      .ham.active span:nth-child(3){transform:translateY(-7px) rotate(-45deg);}
     }
-
-    @supports (backdrop-filter: blur(15px)) {
-      .header {
-        background: rgba(10, 10, 10, 0.7);
-        backdrop-filter: blur(15px);
-        -webkit-backdrop-filter: blur(15px);
-      }
-    }
-
-    .header-container {
-      max-width: 80rem;
-      margin: 0 auto;
-      padding: 0.3rem 1.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .logo-container { display: flex; align-items: center; }
-    .logo { height: 3rem; width: auto; }
-
-    .nav {
-      display: flex;
-      align-items: center;
-      gap: 2.5rem;
-    }
-
-    .nav a {
-      color: var(--white);
-      text-decoration: none;
-      font-size: 0.85rem;
-      font-weight: 400;
-      letter-spacing: 0.05em;
-      position: relative;
-      padding: 10px 0;
-    }
-
-    .nav a[aria-current="page"] { color: var(--gold); }
-
-    .nav a::after {
-      content: '';
-      position: absolute;
-      bottom: 2px; left: 0; right: 0;
-      height: 1px;
-      background: var(--gold);
-      transform: scaleX(0);
-      transition: transform 0.3s ease;
-    }
-
-    .nav a[aria-current="page"]::after { transform: scaleX(1); }
-
-    /* Slot hover */
-    .slot {
-      position: relative;
-      overflow: hidden;
-      display: inline-block;
-      height: 1.1em;
-      line-height: 1.1em;
-    }
-
-    .slot span { display: block; transition: transform 0.5s ease; line-height: 1.1em; }
-
-    .slot .bottom {
-      position: absolute;
-      top: 0; left: 0; width: 100%;
-      transform: translateY(-100%);
-    }
-
-    .nav a:hover .slot .top { transform: translateY(100%); }
-    .nav a:hover .slot .bottom { transform: translateY(0); }
-
-    /* Hamburger */
-    .hamburger {
-      display: none;
-      flex-direction: column;
-      gap: 6px;
-      cursor: pointer;
-      z-index: 9999;
-    }
-
-    .hamburger span {
-      width: 26px;
-      height: 2px;
-      background: var(--white);
-      border-radius: 2px;
-      transition: 0.3s;
-    }
-
-    .hamburger.active span:nth-child(1) { transform: translateY(8px) rotate(45deg); }
-    .hamburger.active span:nth-child(2) { opacity: 0; }
-    .hamburger.active span:nth-child(3) { transform: translateY(-8px) rotate(-45deg); }
-
-    @media (max-width: 900px) {
-      .nav { display: none !important; }
-      .hamburger { display: flex !important; }
-    }
-
-    /* ============================================================
-       MOBILE MENU
-    ============================================================ */
-    .sm-wrapper {
-      position: fixed;
-      inset: 0;
-      pointer-events: none;
-      z-index: 200000;
-    }
-
-    .sm-wrapper.active { pointer-events: auto; }
-
-    .sm-backdrop {
-      position: absolute;
-      inset: 0;
-      background: rgba(0, 0, 0, 0.7);
-      opacity: 0;
-    }
-
-    .sm-panel {
-      position: absolute;
-      top: 0; right: 0;
-      width: min(80vw, 360px);
-      height: 100%;
-      background: var(--dark-2);
-      border-left: 1px solid rgba(201, 168, 76, 0.2);
-      padding: 6.5rem 2rem;
-      transform: translateX(100%);
-    }
-
-    .sm-list { list-style: none; }
-    .sm-list li { overflow: hidden; margin-bottom: 1.8rem; }
-
-    .sm-list a {
-      display: block;
-      font-size: clamp(1.4rem, 4.5vw, 1.9rem);
-      font-weight: 400;
-      color: var(--white);
-      text-decoration: none;
-      letter-spacing: 0.03em;
-      transform: translateY(140%);
-      display: block;
-    }
-
-    .sm-list a:hover { color: var(--gold); }
-
-    @media (min-width: 901px) { .sm-wrapper { display: none; } }
 
     /* ============================================================
        PAGE HERO
     ============================================================ */
     .page-hero {
-      padding: calc(var(--header-h) + 5rem) 1.5rem 3rem;
+      padding: 120px 1.5rem 3rem;
       max-width: 80rem;
       margin: 0 auto;
     }
@@ -782,38 +667,31 @@
     .modal-close-text:hover { border-color: rgba(240, 237, 232, 0.5); }
   </style>
 </head>
-<body>
+<body class="reveal">
 
-  <!-- ── NAVBAR ─── -->
-  <header class="header" id="header">
-    <div class="header-container">
-      <div class="logo-container">
-        <a href="/" style="line-height:0">
-          <img src="logo.jpg" class="logo" alt="D4A logo" />
-        </a>
-      </div>
-      <nav class="nav">
-        <a href="/"><span class="slot"><span class="top">Home</span><span class="bottom">Home</span></span></a>
-        <a href="projects.html" aria-current="page"><span class="slot"><span class="top">Projects</span><span class="bottom">Projects</span></span></a>
-        <a href="aboutus.html"><span class="slot"><span class="top">About Us</span><span class="bottom">About Us</span></span></a>
-      </nav>
-      <div class="hamburger" id="hamburgerBtn">
-        <span></span><span></span><span></span>
-      </div>
-    </div>
-  </header>
-
-  <!-- ── MOBILE MENU ─── -->
-  <div class="sm-wrapper" id="smWrapper">
-    <div class="sm-backdrop" id="smBackdrop"></div>
-    <aside class="sm-panel" id="smPanel">
-      <ul class="sm-list">
-        <li><a href="/">Home</a></li>
-        <li><a href="projects.html">Projects</a></li>
-        <li><a href="aboutus.html">About Us</a></li>
-      </ul>
-    </aside>
+<nav>
+  <a class="logo" href="index.html">
+    <img src="logo.jpg" alt="D4A Studio">
+  </a>
+  <ul class="navlinks">
+    <li><a href="index.html"><span>H</span><span>O</span><span>M</span><span>E</span></a></li>
+    <li><a href="projects.html"><span>P</span><span>R</span><span>O</span><span>J</span><span>E</span><span>C</span><span>T</span><span>S</span></a></li>
+    <li><a href="aboutus.html"><span>A</span><span>B</span><span>O</span><span>U</span><span>T</span><span>U</span><span>S</span></a></li>
+  </ul>
+  <div class="ham" id="ham">
+    <span></span>
+    <span></span>
+    <span></span>
   </div>
+</nav>
+
+<div id="mob-nav">
+  <ul class="mob-links">
+    <li><a href="index.html">HOME</a></li>
+    <li><a href="projects.html">PROJECTS</a></li>
+    <li><a href="aboutus.html">ABOUT</a></li>
+  </ul>
+</div>
 
   <!-- ── PAGE HERO ─── -->
   <div class="page-hero">
@@ -1153,34 +1031,19 @@
     }
 
     /* ============================================================
-       HAMBURGER MENU (GSAP)
+       HAMBURGER MENU
     ============================================================ */
-    const hamburger = document.getElementById('hamburgerBtn');
-    const wrapper   = document.getElementById('smWrapper');
-    const panel     = document.getElementById('smPanel');
-    const backdrop  = document.getElementById('smBackdrop');
-    const menuLinks = document.querySelectorAll('.sm-list a');
-    let menuOpen = false;
-
-    gsap.set(panel,     { xPercent: 100 });
-    gsap.set(menuLinks, { yPercent: 140 });
-
-    const tl_menu = gsap.timeline({ paused: true });
-    tl_menu
-      .to(backdrop,  { opacity: 1, duration: 0.3 })
-      .to(panel,     { xPercent: 0, duration: 0.65, ease: 'power4.out' }, 0)
-      .to(menuLinks, { yPercent: 0, duration: 1, ease: 'power4.out', stagger: 0.1 }, 0.2);
-
-    function toggleMenu() {
-      menuOpen = !menuOpen;
-      wrapper.classList.toggle('active', menuOpen);
-      hamburger.classList.toggle('active', menuOpen);
-      if (menuOpen) tl_menu.play(0); else tl_menu.reverse();
-    }
-
-    hamburger.addEventListener('click', (e) => { e.stopPropagation(); toggleMenu(); });
-    backdrop.addEventListener('click', toggleMenu);
-    menuLinks.forEach(link => link.addEventListener('click', toggleMenu));
+    const ham=document.getElementById('ham'),mobNav=document.getElementById('mob-nav');
+    ham.addEventListener('click',()=>{
+      ham.classList.toggle('active');
+      mobNav.classList.toggle('active');
+    });
+    mobNav.querySelectorAll('a').forEach(a=>{
+      a.addEventListener('click',()=>{
+        ham.classList.remove('active');
+        mobNav.classList.remove('active');
+      });
+    });
 
     /* ============================================================
        PROJECT MATRIX — scroll to card on click


### PR DESCRIPTION
I have updated `projects.html` to use the same navigation bar as `index.html`. This involved:
1. **HTML Structure**: Replacing the existing `<header>` and mobile menu elements with the `<nav>`, `.logo`, `.navlinks`, and `#mob-nav` structure from `index.html`.
2. **CSS Styling**: Porting over the navigation styles, including the letter-by-letter hover animations and the custom architectural hamburger menu. I also updated the `:root` variables and adjusted the padding on the `projects.html` hero section to ensure consistent spacing.
3. **JavaScript Logic**: Replacing the GSAP-based menu logic in `projects.html` with the lightweight vanilla JS toggle used in `index.html`.
4. **UX Improvements**: Added `pointer-events: none` to the letter spans in the navigation links on both pages to prevent flickering when hovering over animated text.

The changes have been verified visually for both desktop and mobile viewports using Playwright.

---
*PR created automatically by Jules for task [1991696716640296](https://jules.google.com/task/1991696716640296) started by @Sohan258oss*